### PR TITLE
Feat/118-signup-tests

### DIFF
--- a/e2e/signup.spec.ts
+++ b/e2e/signup.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+
+test('signs up, logs in, lands on home, opens logout dialog, confirms logout', async ({
+  page,
+}) => {
+  await page.goto('http://localhost:7001');
+
+  await page
+    .getByRole('navigation', { name: 'Navigation principale' })
+    .getByRole('button')
+    .click();
+  await page.getByRole('menuitem', { name: 'Inscription / Connexion' }).click();
+
+  const email = `e2e_${Date.now()}@test.dev`;
+
+  const signup = page.locator('form:has(button:has-text("S\'inscrire"))');
+  await signup.getByLabel('Prénom', { exact: true }).fill('John');
+  await signup.getByLabel('Nom', { exact: true }).fill('Doe');
+  await signup.getByLabel('Email', { exact: true }).fill(email);
+  await signup.getByLabel('Mot de passe', { exact: true }).fill('Password123!');
+  await signup
+    .getByLabel('Confirmez le mot de passe', { exact: true })
+    .fill('Password123!');
+  await signup.getByRole('button', { name: "S'inscrire" }).click();
+
+  await expect(page).toHaveURL('http://localhost:7001/user');
+  await page
+    .getByRole('button', { name: 'Se connecter' })
+    .click()
+    .catch(() => {});
+
+  const login = page.locator(`form:has(button:has-text("Se connecter"))`);
+  await login.getByLabel('Email', { exact: true }).fill(email);
+  await login.getByLabel('Mot de passe', { exact: true }).fill('Password123!');
+
+  await Promise.all([
+    page.waitForURL('http://localhost:7001/'),
+    login.getByRole('button', { name: 'Se connecter' }).click(),
+  ]);
+
+  await page
+    .getByRole('navigation', { name: 'Navigation principale' })
+    .getByRole('button')
+    .click();
+  await page.getByRole('menuitem', { name: 'Se déconnecter' }).click();
+  await expect(page).toHaveURL('http://localhost:7001/');
+
+  const dialog = page.locator('[role="dialog"], [role="alertdialog"]').first();
+  await expect(
+    dialog.getByText('Êtes-vous sûr de vouloir vous déconnecter ?')
+  ).toBeVisible();
+  await dialog.getByRole('button', { name: 'Se déconnecter' }).click();
+  await expect(page).toHaveURL('http://localhost:7001/user');
+});

--- a/frontend/src/ __tests__/Signup.integration.test.tsx
+++ b/frontend/src/ __tests__/Signup.integration.test.tsx
@@ -1,20 +1,22 @@
 import '@testing-library/jest-dom';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { MockedProvider, MockedResponse } from '@apollo/client/testing';
-import { Signup } from '@/components/forms/auth/Signup';
-import { SignUpDocument } from '@/lib/graphql/generated/graphql-types';
-import { Login } from '@/components/forms/auth/Login';
+import { InMemoryCache } from '@apollo/client';
 import { useState } from 'react';
 
-// helper rendu intégration
+import { Signup } from '@/components/forms/auth/Signup';
+import { Login } from '@/components/forms/auth/Login';
+import { SignUpDocument } from '@/lib/graphql/generated/graphql-types';
+
 function AuthPortal({ mocks }: { mocks: MockedResponse[] }) {
   const [showLogin, setShowLogin] = useState(false);
+  const cache = new InMemoryCache();
   return (
     <MemoryRouter initialEntries={['/user']}>
-      <MockedProvider mocks={mocks}>
+      <MockedProvider mocks={mocks} cache={cache}>
         {showLogin ? (
           <Login />
         ) : (
@@ -25,9 +27,8 @@ function AuthPortal({ mocks }: { mocks: MockedResponse[] }) {
   );
 }
 
-describe('Signup – integration (Router + Apollo)', () => {
-  //Sucess navigation de signup apres succes et
-  it("succès ➜ navigate('/user') + onToggleForm(true)", async () => {
+describe('Signup integration (Router + Apollo)', () => {
+  it('should switch to Login view after successful signup', async () => {
     const profile = {
       id: '1',
       email: 'john@doe.dev',
@@ -37,46 +38,6 @@ describe('Signup – integration (Router + Apollo)', () => {
       description: '',
     };
 
-    const mocks: MockedResponse[] = [
-      {
-        request: {
-          query: SignUpDocument, // ✅ vrai document du module réel
-          variables: {
-            data: {
-              email: 'john@doe.dev',
-              firstname: 'John',
-              lastname: 'Doe',
-              hashedPassword: 'Abc12345!',
-            },
-          },
-        },
-        result: { data: { signUp: JSON.stringify(profile) } }, // ou la forme attendue par ton schéma
-      },
-    ];
-
-    render(<AuthPortal mocks={mocks} />);
-
-    await userEvent.type(screen.getByLabelText('Prénom'), 'John');
-    await userEvent.type(screen.getByLabelText('Nom'), 'Doe');
-    await userEvent.type(screen.getByLabelText('Email'), 'john@doe.dev');
-    await userEvent.type(screen.getByLabelText('Mot de passe'), 'Abc12345!');
-    await userEvent.type(
-      screen.getByLabelText('Confirmez le mot de passe'),
-      'Abc12345!'
-    );
-    await userEvent.click(screen.getByRole('button', { name: "S'inscrire" }));
-
-    // (facultatif mais très parlant) : on vérifie que le bouton Login est visible
-    // et que celui de Signup n'est plus présent.
-    expect(
-      await screen.findByRole('button', { name: 'Se connecter' })
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: "S'inscrire" })
-    ).not.toBeInTheDocument();
-  });
-
-  it.only('échec ➜ email déjà pris → message erreur + pas de bascule Login', async () => {
     const mocks: MockedResponse[] = [
       {
         request: {
@@ -90,13 +51,12 @@ describe('Signup – integration (Router + Apollo)', () => {
             },
           },
         },
-        result: { data: { signUp: null } }, // simulate failure
+        result: { data: { signUp: JSON.stringify(profile) } },
       },
     ];
 
     render(<AuthPortal mocks={mocks} />);
 
-    // remplir formulaire
     await userEvent.type(screen.getByLabelText('Prénom'), 'John');
     await userEvent.type(screen.getByLabelText('Nom'), 'Doe');
     await userEvent.type(screen.getByLabelText('Email'), 'john@doe.dev');
@@ -107,16 +67,50 @@ describe('Signup – integration (Router + Apollo)', () => {
     );
     await userEvent.click(screen.getByRole('button', { name: "S'inscrire" }));
 
-    // assertions
+    expect(
+      await screen.findByRole('button', { name: 'Se connecter' })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: "S'inscrire" })
+    ).not.toBeInTheDocument();
+  });
+
+  it('should show global error and stay on Signup when email is already taken', async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: {
+          query: SignUpDocument,
+          variables: {
+            data: {
+              email: 'john@doe.dev',
+              firstname: 'John',
+              lastname: 'Doe',
+              hashedPassword: 'Abc12345!',
+            },
+          },
+        },
+        result: { data: { signUp: null } },
+      },
+    ];
+
+    render(<AuthPortal mocks={mocks} />);
+
+    await userEvent.type(screen.getByLabelText('Prénom'), 'John');
+    await userEvent.type(screen.getByLabelText('Nom'), 'Doe');
+    await userEvent.type(screen.getByLabelText('Email'), 'john@doe.dev');
+    await userEvent.type(screen.getByLabelText('Mot de passe'), 'Abc12345!');
+    await userEvent.type(
+      screen.getByLabelText('Confirmez le mot de passe'),
+      'Abc12345!'
+    );
+    await userEvent.click(screen.getByRole('button', { name: "S'inscrire" }));
+
     expect(
       await screen.findByTestId('signup-global-error')
     ).toBeInTheDocument();
-
-    // pas de bascule : le bouton "Se connecter" ne doit pas apparaître
     expect(
       screen.queryByRole('button', { name: 'Se connecter' })
     ).not.toBeInTheDocument();
-    // le bouton signup est toujours là
     expect(
       screen.getByRole('button', { name: "S'inscrire" })
     ).toBeInTheDocument();

--- a/frontend/src/ __tests__/Signup.integration.test.tsx
+++ b/frontend/src/ __tests__/Signup.integration.test.tsx
@@ -1,0 +1,124 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import { Signup } from '@/components/forms/auth/Signup';
+import { SignUpDocument } from '@/lib/graphql/generated/graphql-types';
+import { Login } from '@/components/forms/auth/Login';
+import { useState } from 'react';
+
+// helper rendu intégration
+function AuthPortal({ mocks }: { mocks: MockedResponse[] }) {
+  const [showLogin, setShowLogin] = useState(false);
+  return (
+    <MemoryRouter initialEntries={['/user']}>
+      <MockedProvider mocks={mocks}>
+        {showLogin ? (
+          <Login />
+        ) : (
+          <Signup onToggleForm={(v) => v && setShowLogin(true)} />
+        )}
+      </MockedProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('Signup – integration (Router + Apollo)', () => {
+  //Sucess navigation de signup apres succes et
+  it("succès ➜ navigate('/user') + onToggleForm(true)", async () => {
+    const profile = {
+      id: '1',
+      email: 'john@doe.dev',
+      firstname: 'John',
+      lastname: 'Doe',
+      role: 'USER',
+      description: '',
+    };
+
+    const mocks: MockedResponse[] = [
+      {
+        request: {
+          query: SignUpDocument, // ✅ vrai document du module réel
+          variables: {
+            data: {
+              email: 'john@doe.dev',
+              firstname: 'John',
+              lastname: 'Doe',
+              hashedPassword: 'Abc12345!',
+            },
+          },
+        },
+        result: { data: { signUp: JSON.stringify(profile) } }, // ou la forme attendue par ton schéma
+      },
+    ];
+
+    render(<AuthPortal mocks={mocks} />);
+
+    await userEvent.type(screen.getByLabelText('Prénom'), 'John');
+    await userEvent.type(screen.getByLabelText('Nom'), 'Doe');
+    await userEvent.type(screen.getByLabelText('Email'), 'john@doe.dev');
+    await userEvent.type(screen.getByLabelText('Mot de passe'), 'Abc12345!');
+    await userEvent.type(
+      screen.getByLabelText('Confirmez le mot de passe'),
+      'Abc12345!'
+    );
+    await userEvent.click(screen.getByRole('button', { name: "S'inscrire" }));
+
+    // (facultatif mais très parlant) : on vérifie que le bouton Login est visible
+    // et que celui de Signup n'est plus présent.
+    expect(
+      await screen.findByRole('button', { name: 'Se connecter' })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: "S'inscrire" })
+    ).not.toBeInTheDocument();
+  });
+
+  it.only('échec ➜ email déjà pris → message erreur + pas de bascule Login', async () => {
+    const mocks: MockedResponse[] = [
+      {
+        request: {
+          query: SignUpDocument,
+          variables: {
+            data: {
+              email: 'john@doe.dev',
+              firstname: 'John',
+              lastname: 'Doe',
+              hashedPassword: 'Abc12345!',
+            },
+          },
+        },
+        result: { data: { signUp: null } }, // simulate failure
+      },
+    ];
+
+    render(<AuthPortal mocks={mocks} />);
+
+    // remplir formulaire
+    await userEvent.type(screen.getByLabelText('Prénom'), 'John');
+    await userEvent.type(screen.getByLabelText('Nom'), 'Doe');
+    await userEvent.type(screen.getByLabelText('Email'), 'john@doe.dev');
+    await userEvent.type(screen.getByLabelText('Mot de passe'), 'Abc12345!');
+    await userEvent.type(
+      screen.getByLabelText('Confirmez le mot de passe'),
+      'Abc12345!'
+    );
+    await userEvent.click(screen.getByRole('button', { name: "S'inscrire" }));
+
+    // assertions
+    expect(
+      await screen.findByTestId('signup-global-error')
+    ).toBeInTheDocument();
+
+    // pas de bascule : le bouton "Se connecter" ne doit pas apparaître
+    expect(
+      screen.queryByRole('button', { name: 'Se connecter' })
+    ).not.toBeInTheDocument();
+    // le bouton signup est toujours là
+    expect(
+      screen.getByRole('button', { name: "S'inscrire" })
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/ __tests__/Signup.test.tsx
+++ b/frontend/src/ __tests__/Signup.test.tsx
@@ -1,0 +1,133 @@
+import '@testing-library/jest-dom';
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { Signup } from '@/components/forms/auth/Signup';
+import * as gqlModule from '@/lib/graphql/generated/graphql-types';
+
+const onToggleForm = vi.fn();
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', async (orig) => {
+  const mod: any = await orig();
+  return { ...mod, useNavigate: () => navigateMock };
+});
+
+const signUpMutationMock = vi.fn();
+vi.mock('@/lib/graphql/generated/graphql-types', () => {
+  return { useSignUpMutation: () => [signUpMutationMock] };
+});
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: any) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('Signup-unit', () => {
+  it('should render all form fields and the signup button', () => {});
+
+  render(<Signup onToggleForm={onToggleForm} />);
+  expect(screen.getByLabelText('Prénom')).toBeInTheDocument();
+  expect(screen.getByLabelText('Nom')).toBeInTheDocument();
+  expect(screen.getByLabelText('Email')).toBeInTheDocument();
+  expect(screen.getByLabelText('Mot de passe')).toBeInTheDocument();
+  expect(
+    screen.getByLabelText('Confirmez le mot de passe')
+  ).toBeInTheDocument();
+
+  expect(
+    screen.getByRole('button', { name: "S'inscrire" })
+  ).toBeInTheDocument();
+
+  it('should mark all fields as required', () => {
+    render(<Signup onToggleForm={onToggleForm} />);
+
+    expect(screen.getByLabelText('Prénom')).toBeRequired();
+    expect(screen.getByLabelText('Nom')).toBeRequired();
+    expect(screen.getByLabelText('Email')).toBeRequired();
+    expect(screen.getByLabelText('Mot de passe')).toBeRequired();
+    expect(screen.getByLabelText('Confirmez le mot de passe')).toBeRequired();
+  });
+  it('should set focus on the first invalid field when submitting an empty form', async () => {
+    render(<Signup onToggleForm={onToggleForm} />);
+    await userEvent.click(screen.getByRole('button', { name: "S'inscrire" }));
+    expect(document.activeElement).toBe(screen.getByLabelText('Prénom'));
+  });
+
+  it('should display an error and set aria-invalid for an invalid email', async () => {
+    render(<Signup onToggleForm={onToggleForm} />);
+    await userEvent.type(screen.getByLabelText('Prénom'), 'John');
+    await userEvent.type(screen.getByLabelText('Nom'), 'Doe');
+    await userEvent.type(screen.getByLabelText('Mot de passe'), 'Abc12345!');
+    await userEvent.type(
+      screen.getByLabelText('Confirmez le mot de passe'),
+      'Abc12345!'
+    );
+    const email = screen.getByLabelText('Email');
+    await userEvent.type(email, 'foo@'); // invalide
+    await userEvent.click(screen.getByRole('button', { name: "S'inscrire" }));
+
+    expect(email).toHaveAttribute('aria-invalid', 'true');
+    const msg = document.getElementById('email-error');
+    expect(msg).toBeTruthy();
+    expect(msg?.textContent).not.toBe('');
+  });
+
+  it('should display a password mismatch error', async () => {
+    render(<Signup onToggleForm={onToggleForm} />);
+    await userEvent.type(screen.getByLabelText('Prénom'), 'John');
+    await userEvent.type(screen.getByLabelText('Nom'), 'Doe');
+    await userEvent.type(screen.getByLabelText('Email'), 'john@doe.dev');
+    await userEvent.type(screen.getByLabelText('Mot de passe'), 'Abc12345!');
+    await userEvent.type(
+      screen.getByLabelText('Confirmez le mot de passe'),
+      'Abc123'
+    );
+    await userEvent.click(screen.getByRole('button', { name: "S'inscrire" }));
+
+    const confirm = screen.getByLabelText('Confirmez le mot de passe');
+    expect(confirm).toHaveAttribute('aria-invalid', 'true');
+    const msg = document.getElementById('confirmPassword-error');
+    expect(msg).toBeTruthy();
+    expect(msg?.textContent).not.toBe('');
+  });
+
+  it('should show a loading state during form submission', async () => {
+    const d = deferred<{ data: { signUp: string | null } }>();
+    vi.spyOn(gqlModule, 'useSignUpMutation').mockReturnValue([
+      vi.fn().mockImplementation(() => d.promise),
+    ] as any);
+
+    render(<Signup onToggleForm={onToggleForm} />);
+    await userEvent.type(screen.getByLabelText('Prénom'), 'John');
+    await userEvent.type(screen.getByLabelText('Nom'), 'Doe');
+    await userEvent.type(screen.getByLabelText('Email'), 'john@doe.dev');
+    await userEvent.type(screen.getByLabelText('Mot de passe'), 'Abc12345!');
+    await userEvent.type(
+      screen.getByLabelText('Confirmez le mot de passe'),
+      'Abc12345!'
+    );
+
+    const btn = screen.getByRole('button', { name: "S'inscrire" });
+    await userEvent.click(btn);
+
+    await waitFor(() => {
+      expect(btn).toBeDisabled();
+      expect(btn).toHaveAttribute('aria-busy', 'true');
+      expect(btn).toHaveTextContent('Envoi en cours…');
+    });
+
+    d.resolve({ data: { signUp: null } });
+
+    await waitFor(() => {
+      expect(btn).not.toBeDisabled();
+      expect(btn).toHaveAttribute('aria-busy', 'false');
+      expect(btn).toHaveTextContent("S'inscrire");
+    });
+  });
+});

--- a/frontend/src/ __tests__/Signup.test.tsx
+++ b/frontend/src/ __tests__/Signup.test.tsx
@@ -29,20 +29,20 @@ function deferred<T>() {
 }
 
 describe('Signup-unit', () => {
-  it('should render all form fields and the signup button', () => {});
+  it('should render all form fields and the signup button', () => {
+    render(<Signup onToggleForm={onToggleForm} />);
+    expect(screen.getByLabelText('Prénom')).toBeInTheDocument();
+    expect(screen.getByLabelText('Nom')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    expect(screen.getByLabelText('Mot de passe')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Confirmez le mot de passe')
+    ).toBeInTheDocument();
 
-  render(<Signup onToggleForm={onToggleForm} />);
-  expect(screen.getByLabelText('Prénom')).toBeInTheDocument();
-  expect(screen.getByLabelText('Nom')).toBeInTheDocument();
-  expect(screen.getByLabelText('Email')).toBeInTheDocument();
-  expect(screen.getByLabelText('Mot de passe')).toBeInTheDocument();
-  expect(
-    screen.getByLabelText('Confirmez le mot de passe')
-  ).toBeInTheDocument();
-
-  expect(
-    screen.getByRole('button', { name: "S'inscrire" })
-  ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: "S'inscrire" })
+    ).toBeInTheDocument();
+  });
 
   it('should mark all fields as required', () => {
     render(<Signup onToggleForm={onToggleForm} />);
@@ -53,6 +53,7 @@ describe('Signup-unit', () => {
     expect(screen.getByLabelText('Mot de passe')).toBeRequired();
     expect(screen.getByLabelText('Confirmez le mot de passe')).toBeRequired();
   });
+
   it('should set focus on the first invalid field when submitting an empty form', async () => {
     render(<Signup onToggleForm={onToggleForm} />);
     await userEvent.click(screen.getByRole('button', { name: "S'inscrire" }));

--- a/frontend/src/components/PasswordInput.tsx
+++ b/frontend/src/components/PasswordInput.tsx
@@ -24,6 +24,12 @@ const PasswordInput = forwardRef<HTMLInputElement, InputProps>(
           type="button"
           variant="ghost"
           size="sm"
+          aria-label={
+            showPassword
+              ? 'Masquer le mot de passe'
+              : 'Afficher le mot de passe'
+          }
+          aria-pressed={showPassword}
           className="absolute top-0 right-0 h-full px-3 py-2 hover:bg-transparent"
           onClick={() => setShowPassword((prev) => !prev)}
           disabled={disabled}

--- a/frontend/src/components/forms/auth/Signup.tsx
+++ b/frontend/src/components/forms/auth/Signup.tsx
@@ -20,13 +20,17 @@ import {
 type SignupProps = {
   onToggleForm: (isLoginMode: boolean) => void;
 };
+import type { FieldErrors } from 'react-hook-form';
+import { useState } from 'react';
+import { ApolloError } from '@apollo/client';
 
 export const Signup = ({ onToggleForm }: SignupProps) => {
   const form = useRegisterForm();
   const navigate = useNavigate();
   const [signUpMutation] = useSignUpMutation();
-
+  const [serverError, setServerError] = useState<string | null>(null);
   const onSubmit = async (values: RegisterFormValues) => {
+    setServerError(null);
     try {
       const formatedData: SignUpUserInput = {
         email: values.email,
@@ -46,126 +50,215 @@ export const Signup = ({ onToggleForm }: SignupProps) => {
         navigate('/user');
         onToggleForm(true);
       }
-    } catch (error) {
-      console.error('Form submission error:', error);
+    } catch (err) {
+      if (err instanceof ApolloError) {
+        const gqlMsg = err.graphQLErrors?.[0]?.message;
+
+        if (gqlMsg?.includes('email')) {
+          form.setError('email', { type: 'server', message: gqlMsg });
+        }
+
+        setServerError(gqlMsg ?? 'Erreur inconnue');
+      } else {
+        setServerError('Une erreur est survenue');
+      }
     }
   };
 
+  const onInvalid = (errors: FieldErrors<RegisterFormValues>) => {
+    const first = Object.keys(errors)[0] as
+      | keyof RegisterFormValues
+      | undefined;
+    if (first) form.setFocus(first);
+  };
+
   return (
-    <Form {...form}>
-      <form
-        onSubmit={form.handleSubmit(onSubmit)}
-        className="space-y-2 sm:space-y-4"
-      >
-        <div className="grid gap-4">
-          <FormField
-            control={form.control}
-            name="firstname"
-            render={({ field }) => (
-              <FormItem className="grid gap-2">
-                <FormLabel htmlFor="firstname">Prénom</FormLabel>
-                <FormControl>
-                  <Input
-                    id="firstname"
-                    placeholder="Entrez votre prénom"
-                    autoComplete="given-name"
-                    className="bg-input border-foreground"
-                    {...field}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+    <div>
+      {serverError && (
+        <p
+          data-testid="signup-global-error"
+          role="alert"
+          aria-live="assertive"
+          className="my-2 text-center text-sm text-red-600"
+          id="signup-desc"
+        >
+          {serverError}
+        </p>
+      )}
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit, onInvalid)}
+          className="space-y-2 sm:space-y-4"
+          aria-labelledby="signup-title"
+          aria-describedby={serverError ? 'signup-desc' : undefined}
+          noValidate
+        >
+          <div className="grid gap-4">
+            <FormField
+              control={form.control}
+              name="firstname"
+              render={({ field }) => {
+                const err = form.formState.errors.firstname?.message as
+                  | string
+                  | undefined;
+                const errId = 'firstname-error';
+                return (
+                  <FormItem className="grid gap-2">
+                    <FormLabel htmlFor="firstname">Prénom</FormLabel>
+                    <FormControl>
+                      <Input
+                        id="firstname"
+                        placeholder="Entrez votre prénom"
+                        autoComplete="given-name"
+                        className="bg-input border-foreground"
+                        required
+                        aria-required="true"
+                        aria-invalid={!!err}
+                        aria-describedby={err ? errId : undefined}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage id={errId} role="alert" />
+                  </FormItem>
+                );
+              }}
+            />
 
-          <FormField
-            control={form.control}
-            name="lastname"
-            render={({ field }) => (
-              <FormItem className="grid gap-2">
-                <FormLabel htmlFor="lastname">Nom</FormLabel>
-                <FormControl>
-                  <Input
-                    id="lastname"
-                    placeholder="Doe"
-                    autoComplete="family-name"
-                    className="bg-input border-foreground"
-                    {...field}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+            <FormField
+              control={form.control}
+              name="lastname"
+              render={({ field }) => {
+                const err = form.formState.errors.lastname?.message as
+                  | string
+                  | undefined;
+                const errId = 'lastname-error';
+                return (
+                  <FormItem className="grid gap-2">
+                    <FormLabel htmlFor="lastname">Nom</FormLabel>
+                    <FormControl>
+                      <Input
+                        id="lastname"
+                        placeholder="Doe"
+                        autoComplete="family-name"
+                        required
+                        aria-required="true"
+                        aria-invalid={!!err}
+                        aria-describedby={err ? errId : undefined}
+                        className="bg-input border-foreground"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage id={errId} role="alert" />
+                  </FormItem>
+                );
+              }}
+            />
 
-          <FormField
-            control={form.control}
-            name="email"
-            render={({ field }) => (
-              <FormItem className="grid gap-2">
-                <FormLabel htmlFor="email">Email</FormLabel>
-                <FormControl>
-                  <Input
-                    id="email"
-                    placeholder="johndoe@mail.com"
-                    type="email"
-                    autoComplete="email"
-                    className="bg-input border-foreground"
-                    {...field}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => {
+                const errorMsg = form.formState.errors.email?.message as
+                  | string
+                  | undefined;
+                const errorId = 'email-error';
+                return (
+                  <FormItem className="grid gap-2">
+                    <FormLabel htmlFor="email">Email</FormLabel>
+                    <FormControl>
+                      <Input
+                        id="email"
+                        placeholder="johndoe@mail.com"
+                        type="email"
+                        required
+                        aria-required="true"
+                        autoComplete="email"
+                        aria-invalid={!!errorMsg}
+                        aria-describedby={errorMsg ? errorId : undefined}
+                        className="bg-input border-foreground"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage id={errorId} role="alert" />
+                  </FormItem>
+                );
+              }}
+            />
 
-          <FormField
-            control={form.control}
-            name="password"
-            render={({ field }) => (
-              <FormItem className="grid gap-2">
-                <FormLabel htmlFor="password">Mot de passe</FormLabel>
-                <FormControl>
-                  <PasswordInput
-                    id="password"
-                    placeholder="******"
-                    autoComplete="new-password"
-                    className="bg-input border-foreground"
-                    {...field}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => {
+                const err = form.formState.errors.password?.message as
+                  | string
+                  | undefined;
+                const errId = 'password-error';
+                return (
+                  <FormItem className="grid gap-2">
+                    <FormLabel htmlFor="password">Mot de passe</FormLabel>
+                    <FormControl>
+                      <PasswordInput
+                        id="password"
+                        placeholder="******"
+                        autoComplete="new-password"
+                        required
+                        aria-required="true"
+                        aria-invalid={!!err}
+                        aria-describedby={err ? errId : undefined}
+                        className="bg-input border-foreground"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage id={errId} role="alert" />
+                  </FormItem>
+                );
+              }}
+            />
 
-          <FormField
-            control={form.control}
-            name="confirmPassword"
-            render={({ field }) => (
-              <FormItem className="grid gap-2">
-                <FormLabel htmlFor="confirmPassword">
-                  Confirmez le mot de passe
-                </FormLabel>
-                <FormControl>
-                  <PasswordInput
-                    id="confirmPassword"
-                    placeholder="******"
-                    autoComplete="new-password"
-                    className="bg-input border-foreground"
-                    {...field}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+            <FormField
+              control={form.control}
+              name="confirmPassword"
+              render={({ field }) => {
+                const err = form.formState.errors.confirmPassword?.message as
+                  | string
+                  | undefined;
+                const errId = 'confirmPassword-error';
+                return (
+                  <FormItem className="grid gap-2">
+                    <FormLabel htmlFor="confirmPassword">
+                      Confirmez le mot de passe
+                    </FormLabel>
+                    <FormControl>
+                      <PasswordInput
+                        id="confirmPassword"
+                        placeholder="******"
+                        autoComplete="new-password"
+                        required
+                        aria-required="true"
+                        aria-invalid={!!err}
+                        aria-describedby={err ? errId : undefined}
+                        className="bg-input border-foreground"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage id={errId} role="alert" />
+                  </FormItem>
+                );
+              }}
+            />
 
-          <Button type="submit" className="w-full">
-            S'inscrire
-          </Button>
-        </div>
-      </form>
-    </Form>
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={form.formState.isSubmitting}
+              aria-disabled={form.formState.isSubmitting}
+              aria-busy={form.formState.isSubmitting}
+            >
+              {form.formState.isSubmitting ? 'Envoi en cours…' : "S'inscrire"}
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </div>
   );
 };


### PR DESCRIPTION
Improve Signup accessibility & UX and add tests: 

- added ARIA attributes/roles, 
- linked field errors via aria-describedby, 
- global server-error banner, 
- disabled/aria-busy submit, 
- and focus on the first invalid field.
- added 3 tests (unit, integration, and end-to-end).